### PR TITLE
Add support for complex variable objects

### DIFF
--- a/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlJsonObject.kt
+++ b/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlJsonObject.kt
@@ -1,5 +1,5 @@
 package com.mirego.trikot.graphql
 
-class GraphqlSerializableVariable(
+class GraphqlJsonObject(
     val body: String
 )

--- a/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
+++ b/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
@@ -46,7 +46,7 @@ abstract class AbstractGraphqlQuery<T>(override val deserializer: Deserializatio
         return when (any) {
             is List<*> -> listJson(any)
             is Int -> "$any"
-            is GraphqlSerializableVariable -> any.body
+            is GraphqlJsonObject -> any.body
             else -> "\"${any}\""
         }
     }


### PR DESCRIPTION
Previously, we only supported primitive variables. If we try to send a complex object such as a json then quotes were added around the json object which caused the data to be invalid.

I added a new `GraphqlSerializableVariable` class with a simple body. If we use this object, then we return the body directly which prevents from wrapping quote.

We can now send complex structure such as metadata in this example.

```
json
{
  "variables": {
    "metadata": {
      "building": {
        "floor": null,
        "foundationType": null,
        "mitigationSystem": null,
        "roomType": null,
        "type": null,
        "ventilation": null,
        "yearOfConstruction": null
      },
      "customer": {
        "address": null,
        "city": null,
        "country": null,
        "email": null,
        "name": null,
        "phoneNumber": null,
        "postalCode": null,
        "state": null
      },
      "measurement": {
        "address": null,
        "city": null,
        "country": null,
        "postalCode": null,
        "state": null
      },
      "owner": {
        "address": null,
        "city": null,
        "country": null,
        "email": null,
        "name": null,
        "phoneNumber": null,
        "postalCode": null,
        "state": null
      },
      "user": {
        "email": null,
        "name": null,
        "phoneNumber": null
      },
      "datasetName": "Unnamed020",
      "measurementType": null,
      "delayCode": null,
      "durationCode": null
    }
  }
}
```
