### PR TITLE
Update trikot dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 kotlin.code.style=official
 kotlin_version = 1.3.61
 trikot_foundation_version=0.25.1
-trikot_streams_version=0.49.1
-trikot_http_version=0.16.1
-trikot_datasources_version=0.13.1
+trikot_streams_version=0.54.1
+trikot_http_version=0.17.1
+trikot_datasources_version=0.14.1
 serialization_version=0.14.0
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Since some trikot dependencies now have @JsName over its methods, graph have to use these new versions in order to work on the web.