### PR TITLE
Feature/escape control chars

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 kotlin.code.style=official
 kotlin_version = 1.3.70
-trikot_foundation_version=0.29.1
-trikot_streams_version=0.61.1
-trikot_http_version=0.20.1
-trikot_datasources_version=0.19.1
+trikot_foundation_version=0.30.1
+trikot_streams_version=0.66.1
+trikot_http_version=0.24.1
+trikot_datasources_version=0.21.1
 serialization_version=0.20.0
 android.useAndroidX=true
 android.enableJetifier=true

--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.android.library'
     id 'kotlin-multiplatform'
     id 'org.jlleitschuh.gradle.ktlint'
     id 'mirego.release' version '1.13'
@@ -16,8 +17,23 @@ repositories {
 
 group 'com.mirego.trikot'
 
+android {
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
+
+    defaultConfig {
+        minSdkVersion 14
+        targetSdkVersion 29
+    }
+}
+
 kotlin {
+    android {
+        publishAllLibraryVariants()
+    }
+
     targets {
+        fromPreset(presets.android, 'android')
         fromPreset(presets.jvm, 'jvm')
         fromPreset(presets.js, 'js')
 
@@ -57,6 +73,12 @@ kotlin {
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-test'
                 implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+            }
+        }
+        androidMain {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
             }
         }
         jsMain {

--- a/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
+++ b/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
@@ -14,8 +14,7 @@ abstract class AbstractGraphqlQuery<T>(override val deserializer: Deserializatio
     private val escapedQuery: String
         get() {
             return query
-                .trimIndent()
-                .jsonEscape()
+                .escapeForGraphql()
         }
 
     override val requestBody: String
@@ -46,27 +45,11 @@ abstract class AbstractGraphqlQuery<T>(override val deserializer: Deserializatio
             is Int,
             is Boolean -> "$any"
             is GraphqlJsonObject -> any.body
-            else -> "\"${any.toString().jsonEscape()}\""
+            else -> "\"${any.toString().escapeForGraphql()}\""
         }
     }
 
     private fun listJson(list: List<*>): String {
         return "[${list.filterNotNull().joinToString { anyToJson(it) }}]"
     }
-}
-
-fun String.jsonEscape(): String {
-    val chars = (0x00..0x1f).map { it.toChar() }
-
-    val escapedControlChars = chars.fold(this) { current, value ->
-        current.replace(value, 0x20.toChar())
-    }
-
-    return escapedControlChars
-        .replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\n", " ")
-        .replace("\b", " ")
-        .replace("\r", " ")
-        .replace("\t", " ")
 }

--- a/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/QueryEscaping.kt
+++ b/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/QueryEscaping.kt
@@ -1,0 +1,46 @@
+package com.mirego.trikot.graphql
+
+fun String.escapeForGraphql(): String {
+    return this.fold("") { current, value ->
+        current + value.escapeForGraphql()
+    }
+}
+
+fun Char.escapeForGraphql(): String {
+    return when (this) {
+        0x00.toChar() -> "\\u0000"
+        0x01.toChar() -> "\\u0001"
+        0x02.toChar() -> "\\u0002"
+        0x03.toChar() -> "\\u0003"
+        0x04.toChar() -> "\\u0004"
+        0x05.toChar() -> "\\u0005"
+        0x06.toChar() -> "\\u0006"
+        0x07.toChar() -> "\\u0007"
+        0x08.toChar() -> "\\u0008"
+        0x09.toChar() -> "\\u0009"
+        0x0A.toChar() -> "\\u000A"
+        0x0B.toChar() -> "\\u000B"
+        0x0C.toChar() -> "\\u000C"
+        0x0D.toChar() -> "\\u000D"
+        0x0E.toChar() -> "\\u000E"
+        0x0F.toChar() -> "\\u000F"
+        0x10.toChar() -> "\\u0010"
+        0x11.toChar() -> "\\u0011"
+        0x12.toChar() -> "\\u0012"
+        0x13.toChar() -> "\\u0013"
+        0x14.toChar() -> "\\u0014"
+        0x15.toChar() -> "\\u0015"
+        0x16.toChar() -> "\\u0016"
+        0x17.toChar() -> "\\u0017"
+        0x18.toChar() -> "\\u0018"
+        0x19.toChar() -> "\\u0019"
+        0x1A.toChar() -> "\\u001A"
+        0x1B.toChar() -> "\\u001B"
+        0x1C.toChar() -> "\\u001C"
+        0x1D.toChar() -> "\\u001D"
+        0x1E.toChar() -> "\\u001E"
+        0x1F.toChar() -> "\\u001F"
+        0x5C.toChar() -> "\\\\"
+        else -> this.toString()
+    }
+}

--- a/graphql/src/commonTest/kotlin/com/mirego/trikot/graphql/GraphqlQueryTests.kt
+++ b/graphql/src/commonTest/kotlin/com/mirego/trikot/graphql/GraphqlQueryTests.kt
@@ -1,10 +1,8 @@
 package com.mirego.trikot.graphql
 
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class GraphqlQueryTests {
 
@@ -15,21 +13,19 @@ class GraphqlQueryTests {
         assertEquals("{\"query\": \"${expectedString()}\",\"variables\": {\"var\":\"${expectedString()}\"}}", query.requestBody)
     }
 
+    class QueryTest : AbstractGraphqlQuery<String>(String.serializer()) {
+        override val variables = mapOf("var" to stringToEscape())
 
-    class QueryTest: AbstractGraphqlQuery<String>(String.serializer()) {
-        override val variables = mapOf("var" to stringToEscape() + "1234")
-
-        override val query = stringToEscape() + "1234"
+        override val query = stringToEscape()
     }
 }
 
 fun expectedString(): String {
-    return stringToEscape().map { " " }.joinToString("") + "1234"
+    return "\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\\u0009\\u000A\\u000B\\u000C\\u000D\\u000E\\u000F\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001A\\u001B\\u001C\\u001D\\u001E\\u001F" + "\\u000D\\\\1234"
 }
 
 fun stringToEscape(): String {
     return (0x00..0x1f).fold("") { current, value ->
         current + value.toChar()
-    }
+    } + "\r\\1234"
 }
-

--- a/graphql/src/main/AndroidManifest.xml
+++ b/graphql/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.mirego.trikot.graphql.android"/>


### PR DESCRIPTION
Escape all control chars to make sure the query is valid

Note: I had to map control characters manually as KMP does not support Ord out of the box.